### PR TITLE
Enhance ServicePackageController with detailed API documentation for …

### DIFF
--- a/src/modules/service-package/service-package.controller.ts
+++ b/src/modules/service-package/service-package.controller.ts
@@ -217,6 +217,64 @@ export class ServicePackageController {
   @ApiResponse({ status: 400, description: 'Dữ liệu không hợp lệ' })
   @UseInterceptors(FileFieldsInterceptor([{ name: 'images', maxCount: 10 }]))
   @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    description: 'Dữ liệu và tệp của concept dịch vụ',
+    schema: {
+      type: 'object',
+      properties: {
+        name: { 
+          type: 'string', 
+          example: 'Chụp hình cưới ngoại cảnh',
+          description: 'Tên của concept dịch vụ'
+        },
+        description: { 
+          type: 'string', 
+          example: 'Concept chụp hình cưới ngoại cảnh với phong cách tự nhiên',
+          nullable: true,
+          description: 'Mô tả chi tiết về concept dịch vụ'
+        },
+        price: { 
+          type: 'number', 
+          example: 5000000,
+          description: 'Giá của concept dịch vụ'
+        },
+        duration: { 
+          type: 'number', 
+          example: 120,
+          description: 'Thời gian thực hiện (phút)'
+        },
+        servicePackageId: { 
+          type: 'string', 
+          example: '123e4567-e89b-12d3-a456-426614174000',
+          description: 'ID của gói dịch vụ'
+        },
+        serviceTypeIds: {
+          type: 'array',
+          items: {
+            type: 'string'
+          },
+          example: ['ST001', 'ST002'],
+          description: 'Danh sách ID của các loại dịch vụ'
+        },
+        status: { 
+          type: 'string', 
+          enum: Object.values(ServiceConceptStatus), 
+          example: ServiceConceptStatus.ACTIVE,
+          nullable: true,
+          description: 'Trạng thái của concept dịch vụ'
+        },
+        images: { 
+          type: 'array',
+          items: {
+            type: 'string',
+            format: 'binary'
+          },
+          description: 'Danh sách ảnh của concept dịch vụ (tối đa 10 ảnh)'
+        },
+      },
+      required: ['name', 'price', 'duration', 'servicePackageId', 'serviceTypeIds'],
+    },
+  })
   async createServiceConcept(
     @Body() createServiceConceptDto: CreateServiceConceptDto,
     @UploadedFiles() files: { images?: Express.Multer.File[] },


### PR DESCRIPTION
…service concept creation

- Added comprehensive API body schema for the createServiceConcept endpoint, detailing required and optional fields, including name, description, price, duration, servicePackageId, serviceTypeIds, status, and images.
- Improved clarity on the expected data structure for service concept submissions, facilitating better integration and usage by clients.